### PR TITLE
Update to repository link that has moved

### DIFF
--- a/index.html
+++ b/index.html
@@ -385,7 +385,7 @@ ninja.logInventory();
 			<h2>Anything You Can Do I Can Do Better</h2>
 		
 			<p>
-				If you look at the things jQuery can do, there's often a counterpart in MooTools. If you look at the things MooTools can do, there is often no way to emulate it using jQuery code because of jQuery's focus on the DOM. MooTools has a broader functionality than jQuery, but  there's nothing about jQuery that prevents you from doing those things. For example, jQuery does not come with any sort of inheritance system, but that's ok. You could, if you want, use the MooTools <em>Class</em> in conjunction with jQuery if you wanted to (or write your own). There's even <a href="http://code.google.com/p/jquery-inheritance/updates/list">an inheritance plug-in for jQuery</a> (I haven't used it, but I assume it offers pretty much the same kind of functionality).
+				If you look at the things jQuery can do, there's often a counterpart in MooTools. If you look at the things MooTools can do, there is often no way to emulate it using jQuery code because of jQuery's focus on the DOM. MooTools has a broader functionality than jQuery, but  there's nothing about jQuery that prevents you from doing those things. For example, jQuery does not come with any sort of inheritance system, but that's ok. You could, if you want, use the MooTools <em>Class</em> in conjunction with jQuery if you wanted to (or write your own). There's even <a href="https://github.com/dfilatov/jquery-plugins/tree/master/src/jquery.inherit">an inheritance plug-in for jQuery</a> (I haven't used it, but I assume it offers pretty much the same kind of functionality).
 			</p>
 	
 			<p>If we look at the example from jQuery above:</p>  


### PR DESCRIPTION
Update the link to the jQuery inheritance plugin that has moved from http://code.google.com/p/jquery-inheritance/updates/list has moved to https://github.com/dfilatov/jquery-plugins/tree/master/src/jquery.inherit.
